### PR TITLE
Fix setup

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,4 +4,3 @@ marionette-predeployed==1.0.0
 filestorage-predeployed==1.0.1b0
 config-controller-predeployed==1.0.1.dev1
 multisigwallet-predeployed==1.1.0b0
-predeployed-generator==1.0.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,6 +1,8 @@
-ima-predeployed==1.3.0
-etherbase-predeployed==1.0.0
-marionette-predeployed==1.0.0
-filestorage-predeployed==1.0.1b0
-config-controller-predeployed==1.0.1.dev1
+ima-predeployed==1.3.5b1
+etherbase-predeployed==1.1.0b1
+marionette-predeployed==2.0.0b0
 multisigwallet-predeployed==1.1.0b0
+predeployed-generator==1.1.0a8
+context-predeployed==1.0.0b0
+filestorage-predeployed==1.1.0b2
+config-controller-predeployed==1.0.1b0


### PR DESCRIPTION
During the installation I faced with this problem:
```
ERROR: Cannot install -r scripts/requirements.txt (line 2), -r scripts/requirements.txt (line 3), -r scripts/requirements.txt (line 4), -r scripts/requirements.txt (line 5) and predeployed-generator==1.0.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested predeployed-generator==1.0.0
    etherbase-predeployed 1.0.0 depends on predeployed-generator>=0.0.1a4
    marionette-predeployed 1.0.0 depends on predeployed-generator
    filestorage-predeployed 1.0.1b0 depends on predeployed-generator
    config-controller-predeployed 1.0.1.dev1 depends on predeployed-generator>=1.1.0a0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
WARNING: You are using pip version 21.2.4; however, version 23.0.1 is available.
You should consider upgrading via the '/Users/payvint/Documents/Blockchain/multisigwallet-cli/venv/bin/python3 -m pip install --upgrade pip' command.
Traceback (most recent call last):
  File "/Users/payvint/Documents/Blockchain/multisigwallet-cli/scripts/generate_abi.py", line 8, in <module>
    from marionette_predeployed import MARIONETTE_ADDRESS
ModuleNotFoundError: No module named 'marionette_predeployed'
```

So looks like there is conflict of "redeployed_generator" version in different packages.
So this PR will remove strict version of generator